### PR TITLE
fix: get whitelist from correct property

### DIFF
--- a/lib/LanguageDetector.js
+++ b/lib/LanguageDetector.js
@@ -107,7 +107,7 @@ class LanguageDetector {
   }
 
   getSimilarInWhitelist (cleanedLng) {
-    if (!this.i18nOptions.whitelist) return
+    if (!this.allOptions.whitelist) return
 
     if (cleanedLng.includes('-')) {
       // i.e. es-MX should check if es is in whitelist
@@ -122,7 +122,7 @@ class LanguageDetector {
     }
 
     // i.e. 'pt' should return 'pt-BR'. If multiple in whitelist with 'pt-', then use first one in whitelist
-    const similar = this.i18nOptions.whitelist.find((whitelistLng) => {
+    const similar = this.allOptions.whitelist.find((whitelistLng) => {
       const cleanedWhitelistLng = this.services.languageUtils.formatLanguageCode(whitelistLng)
       if (cleanedWhitelistLng.startsWith(cleanedLng)) return cleanedWhitelistLng
     })


### PR DESCRIPTION
The used property `i18nOptions` does not exist. It should be `allOptions`.

Is it possible that someone of you force-pushed this change? Because a few days ago everything worked fine. I tried to deploy my project yesterday on a new server and then got the error message `TypeError: Cannot read property 'whitelist' of undefined`. I debugged it and traced it to `LanguageDetector.js:157:29` where you check for `i18nOptions` which does not exist. It worked locally and after removing the `node_modules` folder and reinstalling i got the same error as on my server. That tells me that the code changed but the version did not!

#### Checklist

- [x] only relevant code is changed
- [x] run tests `npm run test`