### PR TITLE
Update httpFunctions.js

### DIFF
--- a/lib/httpFunctions.js
+++ b/lib/httpFunctions.js
@@ -49,7 +49,7 @@ export const getCookies = (req) => {
     const rc = getHeaders(req).cookie
     rc && rc.split(';').forEach((cookie) => {
       const parts = cookie.split('=')
-      list[parts.shift().trim()] = decodeURI(parts.join('='))
+      list[parts.shift().trim()] = decodeURI(encodeURI(parts.join('=')))
     })
     return list
   }

--- a/test/languageDetector.js
+++ b/test/languageDetector.js
@@ -19,6 +19,17 @@ describe('language detector', () => {
       expect(lng).to.eql('de')
       // expect(res).to.eql({})
     })
+    
+    it.only('shouldn\'t fail on URI malformed from cookie content', () => {
+      const req = {
+        headers: {
+          cookie: 'i18next=%'
+        }
+      }
+      const res = {}
+      const lng = ld.detect(req, res)
+      expect(lng).to.eql('%')
+    })
 
     it('cacheUserLanguage', () => {
       const req = {}

--- a/test/languageDetector.js
+++ b/test/languageDetector.js
@@ -19,7 +19,7 @@ describe('language detector', () => {
       expect(lng).to.eql('de')
       // expect(res).to.eql({})
     })
-    
+
     it.only('shouldn\'t fail on URI malformed from cookie content', () => {
       const req = {
         headers: {


### PR DESCRIPTION
Hello
I would suggest to `encodeURI` the result of `cookie.split` in case of for some reason a `%` is not encoded inside, it will break the function with a `URIError: URI malformed` error