### PR TITLE
Support async language detector

### DIFF
--- a/lib/LanguageDetector.js
+++ b/lib/LanguageDetector.js
@@ -27,6 +27,7 @@ function getDefaults () {
 class LanguageDetector {
   constructor (services, options = {}, allOptions = {}) {
     this.type = 'languageDetector'
+    this.async = true
     this.detectors = {}
 
     this.init(services, options, allOptions)
@@ -48,16 +49,20 @@ class LanguageDetector {
     this.detectors[detector.name] = detector
   }
 
-  detect (req, res, detectionOrder) {
-    if (arguments.length < 2) return
+  async detect (req, res, detectionOrder) {
+    if (arguments.length < 2) {
+      const setLng = req
+      setLng()
+      return
+    }
     if (!detectionOrder) detectionOrder = this.options.order
 
     let found
-    detectionOrder.forEach(detectorName => {
-      if (found || !this.detectors[detectorName]) return
+    for (const detectorName of detectionOrder) {
+      if (found || !this.detectors[detectorName]) break
 
-      let detections = this.detectors[detectorName].lookup(req, res, this.options)
-      if (!detections) return
+      let detections = await this.detectors[detectorName].lookup(req, res, this.options)
+      if (!detections) continue
       if (!Array.isArray(detections)) detections = [detections]
 
       detections = detections.filter((d) => d !== undefined && d !== null)
@@ -75,7 +80,7 @@ class LanguageDetector {
       } else {
         found = detections.length > 0 ? detections[0] : null // a little backward compatibility
       }
-    })
+    }
 
     if (!found) {
       let fallbacks = this.allOptions.fallbackLng

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ const checkForCombinedReqRes = (req, res, next) => {
 export function handle (i18next, options = {}) {
   extendOptionsWithDefaults(options)
 
-  return function i18nextMiddleware (rq, rs, n) {
+  return async function i18nextMiddleware (rq, rs, n) {
     const { req, res, next } = checkForCombinedReqRes(rq, rs, n)
 
     if (typeof options.ignoreRoutes === 'function') {
@@ -57,7 +57,7 @@ export function handle (i18next, options = {}) {
     })
 
     let lng = req.lng
-    if (!lng && i18next.services.languageDetector) lng = i18next.services.languageDetector.detect(req, res)
+    if (!lng && i18next.services.languageDetector) lng = await i18next.services.languageDetector.detect(req, res)
 
     // set locale
     req.language = req.locale = req.lng = lng

--- a/test/languageDetector.js
+++ b/test/languageDetector.js
@@ -8,26 +8,26 @@ describe('language detector', () => {
   const ld = new LanguageDetector(i18next.services, { order: ['session', 'querystring', 'path', 'cookie', 'header'], cookieSameSite: 'none' })
 
   describe('cookie', () => {
-    it('detect', () => {
+    it('detect', async () => {
       const req = {
         headers: {
           cookie: 'i18next=de'
         }
       }
       const res = {}
-      const lng = ld.detect(req, res)
+      const lng = await ld.detect(req, res)
       expect(lng).to.eql('de')
       // expect(res).to.eql({})
     })
 
-    it('shouldn\'t fail on URI malformed from cookie content', () => {
+    it('shouldn\'t fail on URI malformed from cookie content', async () => {
       const req = {
         headers: {
           cookie: 'i18next=%'
         }
       }
       const res = {}
-      const lng = ld.detect(req, res)
+      const lng = await ld.detect(req, res)
       expect(lng).to.eql('%')
     })
 
@@ -51,31 +51,31 @@ describe('language detector', () => {
   })
 
   describe('header', () => {
-    it('detect', () => {
+    it('detect', async () => {
       const req = {
         headers: {
           'accept-language': 'de'
         }
       }
       const res = {}
-      const lng = ld.detect(req, res)
+      const lng = await ld.detect(req, res)
       expect(lng).to.eql('de')
       // expect(res).to.eql({})
     })
 
-    it('detect special', () => {
+    it('detect special', async () => {
       const req = {
         headers: {
           'accept-language': 'zh-Hans'
         }
       }
       const res = {}
-      const lng = ld.detect(req, res)
+      const lng = await ld.detect(req, res)
       expect(lng).to.eql('zh-Hans')
       // expect(res).to.eql({})
     })
 
-    it('detect with custom regex', () => {
+    it('detect with custom regex', async () => {
       const req = {
         headers: {
           'accept-language': 'zh-Hans'
@@ -83,45 +83,45 @@ describe('language detector', () => {
       }
       const res = {}
       const ldCustom = new LanguageDetector(i18next.services, { order: ['header'], lookupHeaderRegex: /(([a-z]{4})-?([A-Z]{2})?)\s*;?\s*(q=([0-9.]+))?/gi })
-      const lng = ldCustom.detect(req, res)
+      const lng = await ldCustom.detect(req, res)
       expect(lng).to.eql('Hans')
       // expect(res).to.eql({})
     })
   })
 
   describe('path', () => {
-    it('detect', () => {
+    it('detect', async () => {
       const req = {
         url: '/fr-fr/some/route'
       }
       const res = {}
-      const lng = ld.detect(req, res)
+      const lng = await ld.detect(req, res)
       expect(lng).to.eql('fr-FR')
       // expect(res).to.eql({})
     })
   })
 
   describe('querystring', () => {
-    it('detect', () => {
+    it('detect', async () => {
       const req = {
         url: '/fr/some/route?lng=de'
       }
       const res = {}
-      const lng = ld.detect(req, res)
+      const lng = await ld.detect(req, res)
       expect(lng).to.eql('de')
       // expect(res).to.eql({})
     })
   })
 
   describe('session', () => {
-    it('detect', () => {
+    it('detect', async () => {
       const req = {
         session: {
           lng: 'de'
         }
       }
       const res = {}
-      const lng = ld.detect(req, res)
+      const lng = await ld.detect(req, res)
       expect(lng).to.eql('de')
       // expect(res).to.eql({})
     })


### PR DESCRIPTION
We may want to support async language detector, first of all, the async lookup function.

#### Checklist

- [O ] only relevant code is changed (make a diff before you submit the PR)
- [O ] run tests `npm run test`
- [X ] tests are included
- [X ] documentation is changed or added