### PR TITLE
Fix the type of the lookup method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -123,7 +123,7 @@ interface LanguageDetectorInterface {
     req: Request,
     res: Response,
     options?: LanguageDetectorInterfaceOptions
-  ) => string | string[];
+  ) => string | string[] | undefined;
 
   cacheUserLanguage?: (
     req: Request,


### PR DESCRIPTION
The return type of the lookup method can be not only `string | string[]`, but also `undefined`.