### PR TITLE
fix: error in getQuery() of httpFunctions.js

### DIFF
--- a/lib/httpFunctions.js
+++ b/lib/httpFunctions.js
@@ -22,7 +22,9 @@ export const getOriginalUrl = (req) => {
   return getUrl(req)
 }
 export const getQuery = (req) => {
-  if (req.query && typeof req.query.entries === 'function' && typeof Object.fromEntries === 'function') return Object.fromEntries(req.query)
+  try {
+    if (req.query && typeof req.query.entries === 'function' && typeof Object.fromEntries === 'function') return Object.fromEntries(req.query)
+  } catch(e) {}
   if (req.query) return req.query
   if (req.raw && req.raw.query) return req.raw.query
   if (req.ctx && req.ctx.queryParams) return req.ctx.queryParams

--- a/lib/httpFunctions.js
+++ b/lib/httpFunctions.js
@@ -24,7 +24,7 @@ export const getOriginalUrl = (req) => {
 export const getQuery = (req) => {
   try {
     if (req.query && typeof req.query.entries === 'function' && typeof Object.fromEntries === 'function') return Object.fromEntries(req.query)
-  } catch(e) {}
+  } catch (e) {}
   if (req.query) return req.query
   if (req.raw && req.raw.query) return req.raw.query
   if (req.ctx && req.ctx.queryParams) return req.ctx.queryParams


### PR DESCRIPTION
for some weird reason for every request it is throwing this error:
```
TypeError: object is not iterable (cannot read property Symbol(Symbol.iterator))
```

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added