### PR TITLE
Add Fastify type support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,10 @@ declare global {
   }
 }
 
+declare module 'fastify' {
+  interface FastifyRequest extends I18NextRequest {}
+}
+
 interface ExtendedOptions extends Object {
   getPath?: (req: Request) => string;
   getOriginalUrl?: (req: Request) => string;


### PR DESCRIPTION
Added support for Fastify to the types, by using module augmentation. This allows the `i18n` property of a Fastify request to be accessed with the correct type information.

Example:
```ts
fastify.get('/foo', async (req, res) => {
  const lang = req.i18n.languages[0] // req.i18n is typed
  return res.send(lang)
})

```



 For reference see the relevant Fastify [docs](https://www.fastify.io/docs/latest/Reference/TypeScript/#plugins).

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included