### PR TITLE
Support TS5 types exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,16 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./index.d.ts",
       "require": "./cjs/index.js",
       "default": "./esm/index.js"
     },
     "./cjs": {
+      "types": "./index.d.ts",
       "default": "./cjs/index.js"
     },
     "./esm": {
+      "types": "./index.d.ts",
       "default": "./esm/index.js"
     }
   },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Hi! 👋🏻  Looks like TypeScript 5 now requires `"types"` field in every `"exports"` path. 

https://www.typescrixptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

![ezgif-5-b5da1b00ec](https://github.com/i18next/i18next-http-middleware/assets/26577190/264a79ef-c7a6-44fc-88a1-fdc8c45fc41c)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)