### PR TITLE
fix: Fastify no longer complains about the type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
 import {
   Application,
   Handler,
-  NextFunction,
   Request,
   RequestHandler,
   Response,
@@ -80,8 +79,8 @@ export function koaPlugin(i18next: I18next, options?: HandleOptions): (context: 
 export function plugin(
   instance: any,
   options: HandleOptions & { i18next?: I18next },
-  next: NextFunction
-): Handler;
+  next: (err?: Error) => void
+): void;
 
 export function getResourcesHandler(
   i18next: I18next,


### PR DESCRIPTION
aims to fix https://github.com/i18next/i18next-http-middleware/issues/39

Tested with Fastify 5.x, works well.  
Test passes.
I have no idea however if it works for older versions of Fastify and other frameworks.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)