### PR TITLE
Supports the parsing of Deno headers (fixes #94)

### DIFF
--- a/lib/httpFunctions.js
+++ b/lib/httpFunctions.js
@@ -49,8 +49,14 @@ export const getParams = (req) => {
   return {}
 }
 export const getHeaders = (req) => {
-  if (req.headers) return req.headers
-  console.log('no possibility found to get headers')
+  if (!req.headers) {
+    console.log('no possibility found to get headers')
+    return
+  }
+  if (req.headers.constructor === Headers) {
+    return Object.fromEntries(req.headers.entries())
+  }
+  return req.headers
 }
 export const getCookies = (req) => {
   if (req.cookies) return req.cookies

--- a/test/languageDetector.js
+++ b/test/languageDetector.js
@@ -398,6 +398,17 @@ describe('language detector (ISO 15897 locales)', () => {
       expect(lng).to.eql('pt_BR')
       // expect(res).to.eql({})
     })
+
+    it('handles JS Headers objects', () => {
+      const headers = new Headers()
+      headers.append('accept-language', 'pt-BR,pt;q=0.9,es-419;q=0.8,en;q=0.7')
+      const req = {
+        headers
+      }
+      const res = {}
+      const lng = ld.detect(req, res)
+      expect(lng).to.eql('pt_BR')
+    })
   })
 
   describe('path', () => {


### PR DESCRIPTION
This PR solves #94 by updating the `getHeaders` method from the `httpFunctions` module. It applies to cases where the underlying environment i18next is used on provides headers as JS [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) objects, for instance Deno.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)