### PR TITLE
Add Set-Cookie header to response in Fresh plugin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -162,7 +162,7 @@ export function freshPlugin (i18next, options) {
     const placeholder = ctx.state.res
     delete ctx.state.res
     const resp = await ctx.next()
-    
+
     const contentLanguage = placeholder.headers.get('Content-Language')
     if (contentLanguage) {
       resp.headers.set('Content-Language', contentLanguage)
@@ -172,7 +172,7 @@ export function freshPlugin (i18next, options) {
     if (setCookie) {
       resp.headers.set('Set-Cookie', setCookie)
     }
- 
+
     return resp
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,7 +162,17 @@ export function freshPlugin (i18next, options) {
     const placeholder = ctx.state.res
     delete ctx.state.res
     const resp = await ctx.next()
-    resp.headers.set('Content-Language', placeholder.headers.get('Content-Language'))
+    
+    const contentLanguage = placeholder.headers.get('Content-Language')
+    if (contentLanguage) {
+      resp.headers.set('Content-Language', contentLanguage)
+    }
+
+    const setCookie = placeholder.headers.get('Set-Cookie')
+    if (setCookie) {
+      resp.headers.set('Set-Cookie', setCookie)
+    }
+ 
     return resp
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

### Context

Fresh v2.2.2.

### Configuration

```ts
// main.ts
await i18next
  .use(i18nextFsBackend)
  .use(i18nextMiddleware.LanguageDetector)
  .init({
    partialBundledLanguages: true,
    detection: {
      order: ["querystring", "cookie"],
      caches: ["cookie"],
    },
    fallbackLng: Deno.env.get("FRESH_PUBLIC_DEFAULT_LANGUAGE"),
    preload: ["en", "es", "pt"],
    backend: { loadPath: "static/i18n/{{lng}}/{{ns}}.json" },
  });

export const app = new App<State>()
  .use(staticFiles())
  .use(
    (i18nextMiddleware.freshPlugin(i18next, {
      removeLngFromUrl: true,
    }) as unknown) as MaybeLazy<
      Middleware<State>
    >,
  )
  .fsRoutes();
```

### Issue

I noticed that when calling `i18next.changeLanguage` or by requesting a route with query parameter `lng=<lng>` didn't set the cookie in the browser but the language did change. By debugging, I noticed that only the header `Content-Language` was being set, but `Set-Cookie` wasn't. So, when full reloading the page or by accessing via a new tab, the language preference couldn't be restored.