### PR TITLE
Fix cookie header being overwritten instead of appended

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -170,7 +170,7 @@ export function freshPlugin (i18next, options) {
 
     const setCookie = placeholder.headers.get('Set-Cookie')
     if (setCookie) {
-      resp.headers.set('Set-Cookie', setCookie)
+      resp.headers.append('Set-Cookie', setCookie)
     }
 
     return resp


### PR DESCRIPTION
Using `set()` was replacing existing Set-Cookie headers, which would drop cookies from downstream middleware. `append()` correctly preserves multiple cookie headers as allowed by HTTP.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)