### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://github.com/i18next/i18next-http-middleware",
   "repository": {
     "type": "git",
-    "url": "git@github.com:i18next/i18next-http-middleware.git"
+    "url": "git+https://github.com/i18next/i18next-http-middleware.git"
   },
   "bugs": {
     "url": "https://github.com/i18next/i18next-http-middleware/issues"


### PR DESCRIPTION
## Summary
- update package repository metadata from SSH to HTTPS

## Validation
- npm install --no-package-lock --no-fund
- npm test
- node -e metadata assertion for repository, bugs, and homepage fields
- git diff --check
- git ls-remote https://github.com/i18next/i18next-http-middleware.git HEAD